### PR TITLE
feat: add Tavily search provider as configurable alternative to DuckDuckGo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "langchain-google-genai>=2.0.8",
     "langchain-community>=0.3.13",
     "duckduckgo-search>=7.0.0",
+    "tavily-python>=0.5.0",
     "python-dotenv>=1.0.1",
     "beautifulsoup4>=4.12.3",
     "requests>=2.32.3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ langgraph-checkpoint-sqlite>=2.0.0
 
 # Search
 ddgs>=1.0.0
+tavily-python>=0.5.0
 
 # HTTP Client (async-first with HTTP/2 support)
 httpx[http2]>=0.27.0

--- a/src/config.py
+++ b/src/config.py
@@ -58,6 +58,17 @@ class ResearchConfig(BaseModel):
         description="Model for summarizing search results (faster/cheaper)"
     )
     
+    # Search Provider Configuration
+    search_provider: str = Field(
+        default=os.getenv("SEARCH_PROVIDER", "duckduckgo"),
+        description="Search provider: 'duckduckgo' or 'tavily'"
+    )
+
+    tavily_api_key: str = Field(
+        default_factory=lambda: os.getenv("TAVILY_API_KEY", ""),
+        description="Tavily API key (required when SEARCH_PROVIDER=tavily)"
+    )
+
     # Search Configuration
     max_search_queries: int = Field(
         default=int(os.getenv("MAX_SEARCH_QUERIES", "3")),

--- a/src/utils/tools.py
+++ b/src/utils/tools.py
@@ -5,7 +5,12 @@ from langchain_core.tools import tool
 import logging
 import json
 
-from src.utils.web_utils import WebSearchTool as WebSearchImpl, ContentExtractor as ContentExtractorImpl
+from src.utils.web_utils import (
+    WebSearchTool as WebSearchImpl,
+    ContentExtractor as ContentExtractorImpl,
+    DuckDuckGoProvider,
+    TavilyProvider,
+)
 from src.state import SearchResult
 from src.utils.citations import CitationFormatter
 from src.config import config
@@ -15,7 +20,19 @@ logger = logging.getLogger(__name__)
 
 
 # Initialize tool implementations with config values
-_search_impl = WebSearchImpl(max_results=config.max_search_results_per_query)
+def _build_search_providers():
+    """Build the search providers list based on config.search_provider."""
+    if config.search_provider == "tavily":
+        return [TavilyProvider(api_key=config.tavily_api_key or None,
+                               max_results=config.max_search_results_per_query)]
+    # Default: DuckDuckGo
+    return [DuckDuckGoProvider(config.max_search_results_per_query)]
+
+
+_search_impl = WebSearchImpl(
+    max_results=config.max_search_results_per_query,
+    providers=_build_search_providers(),
+)
 _extractor_impl = ContentExtractorImpl(timeout=10)
 _citation_formatter = CitationFormatter()
 

--- a/src/utils/web_utils.py
+++ b/src/utils/web_utils.py
@@ -14,11 +14,12 @@ from abc import ABC, abstractmethod
 import httpx
 from bs4 import BeautifulSoup
 from ddgs import DDGS
+from tavily import AsyncTavilyClient
 
 from src.state import SearchResult
 from src.exceptions import (
-    SearchError, 
-    RateLimitError, 
+    SearchError,
+    RateLimitError,
     ContentExtractionError,
     CircuitOpenError
 )
@@ -276,6 +277,68 @@ class DuckDuckGoProvider(SearchProvider):
             ))
         
         return results
+
+
+class TavilyProvider(SearchProvider):
+    """Tavily search provider with circuit breaker."""
+
+    def __init__(self, api_key: Optional[str] = None, max_results: int = 5):
+        self.max_results = max_results
+        self.client = AsyncTavilyClient(api_key=api_key)
+        self.circuit_breaker = CircuitBreaker(
+            name="tavily",
+            failure_threshold=3,
+            reset_timeout=60.0
+        )
+
+    @property
+    def name(self) -> str:
+        return "tavily"
+
+    async def search(self, query: str, max_results: Optional[int] = None) -> List[SearchResult]:
+        if not self.circuit_breaker.can_execute():
+            retry_after = self.circuit_breaker.get_retry_after()
+            raise CircuitOpenError("tavily", retry_after)
+
+        results_count = max_results or self.max_results
+
+        try:
+            logger.info(f"Searching Tavily for: {query}")
+
+            response = await self.client.search(
+                query=query,
+                max_results=results_count,
+                search_depth="basic",
+            )
+
+            self.circuit_breaker.record_success()
+
+            results = []
+            for item in response.get("results", []):
+                results.append(SearchResult(
+                    query=query,
+                    title=item.get("title", ""),
+                    url=item.get("url", ""),
+                    snippet=item.get("content", ""),
+                ))
+
+            logger.info(f"Found {len(results)} results for: {query}")
+            return results
+
+        except CircuitOpenError:
+            raise
+        except Exception as e:
+            self.circuit_breaker.record_failure()
+
+            error_str = str(e).lower()
+            if "rate" in error_str or "limit" in error_str or "429" in error_str:
+                raise RateLimitError(
+                    message=f"Tavily rate limit: {str(e)}",
+                    retry_after=60,
+                    service="tavily"
+                )
+
+            raise SearchError(f"Search failed for '{query}'", details=str(e))
 
 
 class WebSearchTool:


### PR DESCRIPTION
## Summary
- Added `TavilyProvider` class implementing the existing `SearchProvider` ABC in `src/utils/web_utils.py`, using `tavily-python` async client with circuit breaker support
- Added `search_provider` and `tavily_api_key` config fields to `ResearchConfig` in `src/config.py`, sourced from `SEARCH_PROVIDER` and `TAVILY_API_KEY` env vars
- Updated `src/utils/tools.py` to select the active search provider at startup based on `config.search_provider`, keeping DuckDuckGo as default
- Added `tavily-python>=0.5.0` to both `requirements.txt` and `pyproject.toml`

## Files changed
- `src/utils/web_utils.py` — New `TavilyProvider` class with async search and circuit breaker
- `src/config.py` — New `search_provider` and `tavily_api_key` fields
- `src/utils/tools.py` — Provider selection logic via `_build_search_providers()`
- `requirements.txt` — Added `tavily-python>=0.5.0`
- `pyproject.toml` — Added `tavily-python>=0.5.0` to dependencies

## Dependency changes
- Added `tavily-python>=0.5.0` to `requirements.txt` and `pyproject.toml`

## Environment variable changes
- `TAVILY_API_KEY` — Required when `SEARCH_PROVIDER=tavily`
- `SEARCH_PROVIDER` — Optional, defaults to `duckduckgo`; set to `tavily` to use Tavily

## Notes for reviewers
- This is an **additive** migration: DuckDuckGo remains the default provider and all existing functionality is preserved
- Set `SEARCH_PROVIDER=tavily` and provide `TAVILY_API_KEY` to activate Tavily
- Tavily results map `content` field to the `snippet` field of `SearchResult`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Automated Review

- Passed after 1 attempt(s)
- Final review: The Tavily migration is well-implemented and functionally correct. The `TavilyProvider` class correctly follows the existing `SearchProvider` abstraction, uses the async Tavily client properly, mirrors the circuit breaker pattern from `DuckDuckGoProvider`, and maps the Tavily response format (`content` field) to `SearchResult.snippet` accurately. Dependencies are updated in both `requirements.txt` and `pyproject.toml`. The config fields use `default_factory` consistently with the existing pattern for sensitive keys. DuckDuckGo remains the default and is not removed, preserving backward compatibility. There are three minor issues but no critical or major blockers.
