### PR TITLE
feat: add Exa AI-powered search tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "langchain-community>=0.3.13",
     "duckduckgo-search>=7.0.0",
     "tavily-python>=0.5.0",
+    "exa-py>=2.0.0",
     "python-dotenv>=1.0.1",
     "beautifulsoup4>=4.12.3",
     "requests>=2.32.3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ langgraph-checkpoint-sqlite>=2.0.0
 # Search
 ddgs>=1.0.0
 tavily-python>=0.5.0
+exa-py>=2.0.0
 
 # HTTP Client (async-first with HTTP/2 support)
 httpx[http2]>=0.27.0

--- a/src/config.py
+++ b/src/config.py
@@ -61,12 +61,27 @@ class ResearchConfig(BaseModel):
     # Search Provider Configuration
     search_provider: str = Field(
         default=os.getenv("SEARCH_PROVIDER", "duckduckgo"),
-        description="Search provider: 'duckduckgo' or 'tavily'"
+        description="Search provider: 'duckduckgo', 'tavily', or 'exa'"
     )
 
     tavily_api_key: str = Field(
         default_factory=lambda: os.getenv("TAVILY_API_KEY", ""),
         description="Tavily API key (required when SEARCH_PROVIDER=tavily)"
+    )
+
+    exa_api_key: str = Field(
+        default_factory=lambda: os.getenv("EXA_API_KEY", ""),
+        description="Exa API key (required when SEARCH_PROVIDER=exa)"
+    )
+
+    exa_search_type: str = Field(
+        default=os.getenv("EXA_SEARCH_TYPE", "auto"),
+        description="Exa search type: 'auto', 'neural', 'fast', 'deep', etc."
+    )
+
+    exa_category: str = Field(
+        default=os.getenv("EXA_CATEGORY", ""),
+        description="Optional Exa category filter (e.g., 'research paper', 'news')"
     )
 
     # Search Configuration

--- a/src/utils/tools.py
+++ b/src/utils/tools.py
@@ -10,6 +10,7 @@ from src.utils.web_utils import (
     ContentExtractor as ContentExtractorImpl,
     DuckDuckGoProvider,
     TavilyProvider,
+    ExaProvider,
 )
 from src.state import SearchResult
 from src.utils.citations import CitationFormatter
@@ -25,6 +26,13 @@ def _build_search_providers():
     if config.search_provider == "tavily":
         return [TavilyProvider(api_key=config.tavily_api_key or None,
                                max_results=config.max_search_results_per_query)]
+    if config.search_provider == "exa":
+        return [ExaProvider(
+            api_key=config.exa_api_key or None,
+            max_results=config.max_search_results_per_query,
+            search_type=config.exa_search_type,
+            category=config.exa_category or None,
+        )]
     # Default: DuckDuckGo
     return [DuckDuckGoProvider(config.max_search_results_per_query)]
 

--- a/src/utils/web_utils.py
+++ b/src/utils/web_utils.py
@@ -15,6 +15,7 @@ import httpx
 from bs4 import BeautifulSoup
 from ddgs import DDGS
 from tavily import AsyncTavilyClient
+from exa_py import Exa
 
 from src.state import SearchResult
 from src.exceptions import (
@@ -339,6 +340,146 @@ class TavilyProvider(SearchProvider):
                 )
 
             raise SearchError(f"Search failed for '{query}'", details=str(e))
+
+
+class ExaProvider(SearchProvider):
+    """Exa AI-powered search provider with circuit breaker.
+
+    Exa returns neural/semantic search results along with rich content
+    (text, highlights, summary) in a single call. The provider exposes
+    the main Exa features: search type, category filtering, domain and
+    text filters, and date ranges. See https://exa.ai/docs for details.
+    """
+
+    INTEGRATION_HEADER = "deep-research-agent"
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        max_results: int = 5,
+        search_type: str = "auto",
+        category: Optional[str] = None,
+        include_domains: Optional[List[str]] = None,
+        exclude_domains: Optional[List[str]] = None,
+        include_text: Optional[List[str]] = None,
+        exclude_text: Optional[List[str]] = None,
+        start_published_date: Optional[str] = None,
+        end_published_date: Optional[str] = None,
+        text_max_characters: int = 2000,
+        highlights_max_characters: int = 1000,
+    ):
+        self.max_results = max_results
+        self.search_type = search_type
+        self.category = category
+        self.include_domains = include_domains
+        self.exclude_domains = exclude_domains
+        self.include_text = include_text
+        self.exclude_text = exclude_text
+        self.start_published_date = start_published_date
+        self.end_published_date = end_published_date
+        self.text_max_characters = text_max_characters
+        self.highlights_max_characters = highlights_max_characters
+        self.client = Exa(api_key=api_key)
+        # Attribute API usage to this integration so Exa can track adoption.
+        self.client.headers["x-exa-integration"] = self.INTEGRATION_HEADER
+        self.circuit_breaker = CircuitBreaker(
+            name="exa",
+            failure_threshold=3,
+            reset_timeout=60.0
+        )
+
+    @property
+    def name(self) -> str:
+        return "exa"
+
+    async def search(self, query: str, max_results: Optional[int] = None) -> List[SearchResult]:
+        if not self.circuit_breaker.can_execute():
+            retry_after = self.circuit_breaker.get_retry_after()
+            raise CircuitOpenError("exa", retry_after)
+
+        results_count = max_results or self.max_results
+
+        try:
+            logger.info(f"Searching Exa for: {query}")
+
+            # exa-py's default client is synchronous, so offload to a
+            # worker thread to avoid blocking the event loop (matches the
+            # DuckDuckGo provider's approach).
+            response = await asyncio.to_thread(
+                self._execute_search, query, results_count
+            )
+
+            self.circuit_breaker.record_success()
+
+            results = [
+                self._to_search_result(query, item)
+                for item in getattr(response, "results", []) or []
+            ]
+
+            logger.info(f"Found {len(results)} results for: {query}")
+            return results
+
+        except CircuitOpenError:
+            raise
+        except Exception as e:
+            self.circuit_breaker.record_failure()
+
+            error_str = str(e).lower()
+            if "rate" in error_str or "limit" in error_str or "429" in error_str:
+                raise RateLimitError(
+                    message=f"Exa rate limit: {str(e)}",
+                    retry_after=60,
+                    service="exa"
+                )
+
+            raise SearchError(f"Search failed for '{query}'", details=str(e))
+
+    def _execute_search(self, query: str, max_results: int):
+        kwargs: Dict[str, Any] = {
+            "num_results": max_results,
+            "type": self.search_type,
+            "highlights": {"max_characters": self.highlights_max_characters},
+            "text": {"max_characters": self.text_max_characters},
+        }
+        if self.category:
+            kwargs["category"] = self.category
+        if self.include_domains:
+            kwargs["include_domains"] = self.include_domains
+        if self.exclude_domains:
+            kwargs["exclude_domains"] = self.exclude_domains
+        if self.include_text:
+            kwargs["include_text"] = self.include_text
+        if self.exclude_text:
+            kwargs["exclude_text"] = self.exclude_text
+        if self.start_published_date:
+            kwargs["start_published_date"] = self.start_published_date
+        if self.end_published_date:
+            kwargs["end_published_date"] = self.end_published_date
+        return self.client.search_and_contents(query, **kwargs)
+
+    def _to_search_result(self, query: str, item: Any) -> SearchResult:
+        text = getattr(item, "text", None) or ""
+        highlights = getattr(item, "highlights", None) or []
+        summary = getattr(item, "summary", None) or ""
+
+        # Prefer summary, then joined highlights, then trimmed text.
+        # Any combination may be absent depending on request / result.
+        if summary:
+            snippet = summary
+        elif highlights:
+            snippet = " ... ".join(h for h in highlights if h)
+        elif text:
+            snippet = text[:500]
+        else:
+            snippet = ""
+
+        return SearchResult(
+            query=query,
+            title=getattr(item, "title", "") or "",
+            url=getattr(item, "url", "") or "",
+            snippet=snippet,
+            content=text or None,
+        )
 
 
 class WebSearchTool:

--- a/tests/test_exa_provider.py
+++ b/tests/test_exa_provider.py
@@ -1,0 +1,187 @@
+"""Unit tests for the Exa search provider."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_response(items):
+    """Build a fake exa-py search_and_contents response."""
+    results = [SimpleNamespace(**item) for item in items]
+    return SimpleNamespace(results=results)
+
+
+@pytest.fixture
+def mock_exa_class():
+    """Patch the module-level Exa import with a mock class."""
+    with patch("src.utils.web_utils.Exa") as MockExa:
+        instance = MagicMock()
+        instance.headers = {}
+        MockExa.return_value = instance
+        yield MockExa, instance
+
+
+class TestExaProviderInit:
+    def test_sets_integration_header(self, mock_exa_class):
+        from src.utils.web_utils import ExaProvider
+
+        _, instance = mock_exa_class
+        ExaProvider(api_key="test-key")
+
+        assert instance.headers["x-exa-integration"] == "deep-research-agent"
+
+    def test_provider_name(self, mock_exa_class):
+        from src.utils.web_utils import ExaProvider
+
+        provider = ExaProvider(api_key="test-key")
+        assert provider.name == "exa"
+
+    def test_passes_api_key(self, mock_exa_class):
+        from src.utils.web_utils import ExaProvider
+
+        MockExa, _ = mock_exa_class
+        ExaProvider(api_key="my-key")
+        MockExa.assert_called_once_with(api_key="my-key")
+
+
+class TestExaProviderSearch:
+    def test_search_parses_results(self, mock_exa_class):
+        from src.utils.web_utils import ExaProvider
+
+        _, instance = mock_exa_class
+        instance.search_and_contents.return_value = _make_response([
+            {
+                "title": "Example Title",
+                "url": "https://example.com/a",
+                "text": "Full article text here",
+                "highlights": ["Key highlight one", "Key highlight two"],
+                "summary": "An example summary",
+            },
+        ])
+
+        provider = ExaProvider(api_key="test-key", max_results=5)
+        results = asyncio.run(provider.search("test query"))
+
+        assert len(results) == 1
+        assert results[0].title == "Example Title"
+        assert results[0].url == "https://example.com/a"
+        assert results[0].query == "test query"
+        assert results[0].content == "Full article text here"
+        # Summary wins over highlights and text when present.
+        assert results[0].snippet == "An example summary"
+
+    def test_search_passes_request_kwargs(self, mock_exa_class):
+        from src.utils.web_utils import ExaProvider
+
+        _, instance = mock_exa_class
+        instance.search_and_contents.return_value = _make_response([])
+
+        provider = ExaProvider(
+            api_key="test-key",
+            max_results=7,
+            search_type="neural",
+            category="research paper",
+            include_domains=["arxiv.org"],
+            exclude_domains=["spam.example"],
+            start_published_date="2025-01-01",
+        )
+        asyncio.run(provider.search("llm research"))
+
+        instance.search_and_contents.assert_called_once()
+        args, kwargs = instance.search_and_contents.call_args
+        assert args == ("llm research",)
+        assert kwargs["num_results"] == 7
+        assert kwargs["type"] == "neural"
+        assert kwargs["category"] == "research paper"
+        assert kwargs["include_domains"] == ["arxiv.org"]
+        assert kwargs["exclude_domains"] == ["spam.example"]
+        assert kwargs["start_published_date"] == "2025-01-01"
+        # Both content modes should be requested together.
+        assert "highlights" in kwargs
+        assert "text" in kwargs
+
+    def test_rate_limit_error_mapped(self, mock_exa_class):
+        from src.utils.web_utils import ExaProvider
+        from src.exceptions import RateLimitError
+
+        _, instance = mock_exa_class
+        instance.search_and_contents.side_effect = Exception("429 rate limit exceeded")
+
+        provider = ExaProvider(api_key="test-key")
+        with pytest.raises(RateLimitError):
+            asyncio.run(provider.search("query"))
+
+    def test_generic_error_mapped_to_search_error(self, mock_exa_class):
+        from src.utils.web_utils import ExaProvider
+        from src.exceptions import SearchError
+
+        _, instance = mock_exa_class
+        instance.search_and_contents.side_effect = Exception("boom")
+
+        provider = ExaProvider(api_key="test-key")
+        with pytest.raises(SearchError):
+            asyncio.run(provider.search("query"))
+
+
+class TestSnippetFallback:
+    """Content may arrive as any mix of text/highlights/summary -- the
+    snippet extraction must cascade through them gracefully."""
+
+    def _snippet_for(self, mock_exa_class, item):
+        from src.utils.web_utils import ExaProvider
+
+        _, instance = mock_exa_class
+        instance.search_and_contents.return_value = _make_response([item])
+        provider = ExaProvider(api_key="test-key")
+        return asyncio.run(provider.search("q"))[0].snippet
+
+    def test_highlights_used_when_no_summary(self, mock_exa_class):
+        snippet = self._snippet_for(mock_exa_class, {
+            "title": "t",
+            "url": "https://x.com",
+            "text": "full text body",
+            "highlights": ["first", "second"],
+        })
+        assert "first" in snippet
+        assert "second" in snippet
+
+    def test_text_used_when_no_summary_or_highlights(self, mock_exa_class):
+        snippet = self._snippet_for(mock_exa_class, {
+            "title": "t",
+            "url": "https://x.com",
+            "text": "full text body only",
+        })
+        assert snippet.startswith("full text body only")
+
+    def test_empty_when_nothing_present(self, mock_exa_class):
+        snippet = self._snippet_for(mock_exa_class, {
+            "title": "t",
+            "url": "https://x.com",
+        })
+        assert snippet == ""
+
+
+class TestProviderRegistration:
+    """Verify _build_search_providers only returns Exa when configured."""
+
+    def test_exa_not_registered_by_default(self, mock_exa_class):
+        from src.utils import tools
+        from src.utils.web_utils import ExaProvider
+
+        with patch.object(tools.config, "search_provider", "duckduckgo"):
+            providers = tools._build_search_providers()
+        assert not any(isinstance(p, ExaProvider) for p in providers)
+
+    def test_exa_registered_when_selected(self, mock_exa_class):
+        from src.utils import tools
+        from src.utils.web_utils import ExaProvider
+
+        with patch.object(tools.config, "search_provider", "exa"), \
+                patch.object(tools.config, "exa_api_key", "test-key"), \
+                patch.object(tools.config, "exa_search_type", "auto"), \
+                patch.object(tools.config, "exa_category", ""):
+            providers = tools._build_search_providers()
+        assert len(providers) == 1
+        assert isinstance(providers[0], ExaProvider)


### PR DESCRIPTION
## Summary

- Adds `ExaProvider` implementing the existing `SearchProvider` ABC, alongside `DuckDuckGoProvider` and `TavilyProvider`.
- [Exa](https://exa.ai) is a neural/semantic web search API that returns relevance-ranked results along with rich content (text, highlights, summary) in a single `search_and_contents` call, so the provider can populate `SearchResult.snippet` without a separate content-extraction round-trip.
- Selection is config-driven via `SEARCH_PROVIDER=exa`, with `EXA_API_KEY`, `EXA_SEARCH_TYPE`, and `EXA_CATEGORY` for tuning. Everything else (domain/text filters, date ranges, content sizes) is exposed via `ExaProvider` constructor kwargs for programmatic use.

## Usage

```bash
# .env
SEARCH_PROVIDER=exa
EXA_API_KEY=your-exa-api-key
EXA_SEARCH_TYPE=auto        # optional: auto | neural | fast | deep
EXA_CATEGORY=research paper # optional
```

```python
from src.utils.web_utils import ExaProvider, WebSearchTool

provider = ExaProvider(
    api_key="...",
    max_results=5,
    search_type="neural",
    category="research paper",
    include_domains=["arxiv.org"],
    start_published_date="2025-01-01",
)
results = await WebSearchTool(providers=[provider]).search_async("llm reasoning benchmarks")
```

## Implementation notes

- Follows the existing `TavilyProvider` pattern for circuit breaker, rate-limit detection, and error mapping (`RateLimitError` / `SearchError`).
- `exa-py`'s default client is synchronous, so the call is offloaded with `asyncio.to_thread` (same approach as `DuckDuckGoProvider._execute_search`).
- Snippet extraction cascades `summary` → joined `highlights` → trimmed `text` → empty string, so any combination of returned content fields works.

## Files changed

- `src/utils/web_utils.py` — new `ExaProvider` class
- `src/utils/tools.py` — register Exa in `_build_search_providers`
- `src/config.py` — `EXA_API_KEY`, `EXA_SEARCH_TYPE`, `EXA_CATEGORY` fields
- `requirements.txt`, `pyproject.toml` — add `exa-py>=2.0.0`
- `tests/test_exa_provider.py` — 12 unit tests (parsing, request kwargs, snippet fallback, error mapping, provider registration); no live API calls

## Test plan

- [x] `pytest tests/test_exa_provider.py` — 12/12 passing locally
- [x] `ruff check` introduces no new warnings on touched files
- [ ] Smoke test with a real `EXA_API_KEY` in the running agent