### PR TITLE
feat: add optional You.com search provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ https://github.com/user-attachments/assets/df8404c6-7423-4a49-864a-bd4d59885c1b
 | **Checkpointing** | Workflow state persistence for crash recovery |
 | **Typed Exceptions** | Domain-specific error handling for better debugging |
 | **Dependency Injection** | Testable agent architecture with injectable LLMs |
-| **Search Provider Abstraction** | Extensible search backend (DuckDuckGo, with easy addition of others) |
+| **Search Provider Abstraction** | Extensible search backend (DuckDuckGo, Tavily, You.com, with easy addition of others) |
 
 ---
 
@@ -276,6 +276,8 @@ SUMMARIZATION_MODEL=gpt-4o-mini
 # =============================================================================
 # SEARCH SETTINGS (optional)
 # =============================================================================
+SEARCH_PROVIDER=duckduckgo       # Options: duckduckgo, tavily, youcom
+YDC_API_KEY=your_youcom_key_here  # Required when SEARCH_PROVIDER=youcom
 MAX_SEARCH_QUERIES=3               # Number of search queries
 MAX_SEARCH_RESULTS_PER_QUERY=3     # Results per query
 MIN_CREDIBILITY_SCORE=40           # Filter threshold (0-100)
@@ -295,6 +297,14 @@ CITATION_STYLE=apa                 # Options: apa, mla, chicago, ieee
 | **llama.cpp** | Free | Local | Fastest | Manual |
 | **Gemini** | Free tier | Cloud | Fast | API key |
 | **OpenAI** | Pay-per-use | Cloud | Fast | API key |
+
+### Search Providers
+
+| Provider | Notes |
+|----------|-------|
+| **DuckDuckGo** | Default provider, no API key required |
+| **Tavily** | Optional API-key-backed provider |
+| **You.com** | Optional Search API provider via `SEARCH_PROVIDER=youcom` and `YDC_API_KEY` |
 
 ---
 
@@ -546,6 +556,7 @@ Built with:
 - [Chainlit](https://github.com/Chainlit/chainlit) - Web interface
 - [httpx](https://www.python-httpx.org/) - Async HTTP client
 - [DuckDuckGo](https://duckduckgo.com/) - Web search
+- [You.com](https://you.com/docs/api-reference/search/v1-search) - Optional search provider
 
 Supports:
 - [Ollama](https://ollama.com/) & [llama.cpp](https://github.com/ggerganov/llama.cpp) - Local models

--- a/README.md
+++ b/README.md
@@ -556,7 +556,7 @@ Built with:
 - [Chainlit](https://github.com/Chainlit/chainlit) - Web interface
 - [httpx](https://www.python-httpx.org/) - Async HTTP client
 - [DuckDuckGo](https://duckduckgo.com/) - Web search
-- [You.com](https://you.com/docs/api-reference/search/v1-search) - Optional search provider
+- [You.com](https://you.com/docs/api-reference/search/v1-search?utm_source=tarun7r-deep-research-agent&utm_medium=oss_integration&utm_campaign=2026-08-oss-integrations&utm_content=readme) - Optional search provider
 
 Supports:
 - [Ollama](https://ollama.com/) & [llama.cpp](https://github.com/ggerganov/llama.cpp) - Local models

--- a/src/config.py
+++ b/src/config.py
@@ -61,12 +61,22 @@ class ResearchConfig(BaseModel):
     # Search Provider Configuration
     search_provider: str = Field(
         default=os.getenv("SEARCH_PROVIDER", "duckduckgo"),
-        description="Search provider: 'duckduckgo' or 'tavily'"
+        description="Search provider: 'duckduckgo', 'tavily', or 'youcom'"
     )
 
     tavily_api_key: str = Field(
         default_factory=lambda: os.getenv("TAVILY_API_KEY", ""),
         description="Tavily API key (required when SEARCH_PROVIDER=tavily)"
+    )
+
+    youcom_api_key: str = Field(
+        default_factory=lambda: os.getenv("YDC_API_KEY", ""),
+        description="You.com API key (required when SEARCH_PROVIDER=youcom)"
+    )
+
+    youcom_base_url: str = Field(
+        default=os.getenv("YOUCOM_SEARCH_BASE_URL", "https://ydc-index.io/v1/search"),
+        description="You.com Search API URL"
     )
 
     # Search Configuration
@@ -165,4 +175,3 @@ logger = logging.getLogger(__name__)
 logger.info(f"Configuration loaded - MAX_SEARCH_QUERIES: {config.max_search_queries}, "
            f"MAX_SEARCH_RESULTS_PER_QUERY: {config.max_search_results_per_query}, "
            f"MAX_REPORT_SECTIONS: {config.max_report_sections}")
-

--- a/src/utils/tools.py
+++ b/src/utils/tools.py
@@ -10,6 +10,7 @@ from src.utils.web_utils import (
     ContentExtractor as ContentExtractorImpl,
     DuckDuckGoProvider,
     TavilyProvider,
+    YouComProvider,
 )
 from src.state import SearchResult
 from src.utils.citations import CitationFormatter
@@ -22,6 +23,15 @@ logger = logging.getLogger(__name__)
 # Initialize tool implementations with config values
 def _build_search_providers():
     """Build the search providers list based on config.search_provider."""
+    if config.search_provider == "youcom":
+        return [
+            YouComProvider(
+                api_key=config.youcom_api_key or None,
+                base_url=config.youcom_base_url,
+                max_results=config.max_search_results_per_query,
+            ),
+            DuckDuckGoProvider(config.max_search_results_per_query),
+        ]
     if config.search_provider == "tavily":
         return [TavilyProvider(api_key=config.tavily_api_key or None,
                                max_results=config.max_search_results_per_query)]

--- a/src/utils/web_utils.py
+++ b/src/utils/web_utils.py
@@ -3,6 +3,7 @@
 import asyncio
 import re
 import time
+import os
 from typing import List, Optional, Dict, Any
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
@@ -339,6 +340,123 @@ class TavilyProvider(SearchProvider):
                 )
 
             raise SearchError(f"Search failed for '{query}'", details=str(e))
+
+
+class YouComProvider(SearchProvider):
+    """You.com search provider using the Search API."""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: str = "https://ydc-index.io/v1/search",
+        max_results: int = 5,
+    ):
+        self.api_key = api_key or os.getenv("YDC_API_KEY")
+        self.base_url = base_url
+        self.max_results = max_results
+        self.client_manager = HTTPClientManager.get_instance()
+        self.circuit_breaker = CircuitBreaker(
+            name="youcom",
+            failure_threshold=3,
+            reset_timeout=60.0,
+        )
+        self.user_agent = "youdotcom-integration/tarun7r-deep-research-agent"
+
+    @property
+    def name(self) -> str:
+        return "youcom"
+
+    async def search(self, query: str, max_results: Optional[int] = None) -> List[SearchResult]:
+        if not self.circuit_breaker.can_execute():
+            retry_after = self.circuit_breaker.get_retry_after()
+            raise CircuitOpenError("youcom", retry_after)
+
+        if not self.api_key:
+            raise SearchError(
+                "You.com Search API requires YDC_API_KEY when SEARCH_PROVIDER=youcom"
+            )
+
+        results_count = max_results or self.max_results
+
+        try:
+            logger.info(f"Searching You.com for: {query}")
+            client = await self.client_manager.get_client()
+            response = await client.get(
+                self.base_url,
+                params={
+                    "query": query,
+                    "count": results_count,
+                },
+                headers={
+                    "X-API-Key": self.api_key,
+                    "User-Agent": self.user_agent,
+                },
+            )
+
+            if response.status_code == 429:
+                self.circuit_breaker.record_failure()
+                raise RateLimitError(
+                    message=f"You.com rate limit: {response.text}",
+                    retry_after=60,
+                    service="youcom",
+                )
+
+            response.raise_for_status()
+            payload = response.json()
+
+            self.circuit_breaker.record_success()
+
+            results = self._parse_results(query, payload, results_count)
+            logger.info(f"Found {len(results)} You.com results for: {query}")
+            return results
+
+        except CircuitOpenError:
+            raise
+        except RateLimitError:
+            raise
+        except Exception as e:
+            self.circuit_breaker.record_failure()
+            error_str = str(e).lower()
+            if "429" in error_str or "rate" in error_str or "limit" in error_str:
+                raise RateLimitError(
+                    message=f"You.com rate limit: {str(e)}",
+                    retry_after=60,
+                    service="youcom",
+                )
+            raise SearchError(f"Search failed for '{query}'", details=str(e))
+
+    def _parse_results(
+        self,
+        query: str,
+        payload: Dict[str, Any],
+        max_results: int,
+    ) -> List[SearchResult]:
+        results: List[SearchResult] = []
+        results_block = payload.get("results", {})
+        web_section = results_block.get("web", []) if isinstance(results_block, dict) else []
+        if not isinstance(web_section, list):
+            web_section = []
+
+        for item in web_section[:max_results]:
+            title = item.get("title") or ""
+            url = item.get("url") or ""
+            snippets = item.get("snippets") or []
+            if isinstance(snippets, list) and snippets:
+                snippet = snippets[0]
+            else:
+                snippet = item.get("description") or ""
+
+            if not title or not url:
+                continue
+
+            results.append(SearchResult(
+                query=query,
+                title=title,
+                url=url,
+                snippet=snippet,
+            ))
+
+        return results
 
 
 class WebSearchTool:

--- a/tests/test_youcom_provider.py
+++ b/tests/test_youcom_provider.py
@@ -1,0 +1,106 @@
+import pytest
+
+from src.utils.tools import _build_search_providers
+from src.utils.web_utils import DuckDuckGoProvider, YouComProvider
+
+
+class _FakeResponse:
+    def __init__(self, payload, status_code=200, text="ok"):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = text
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self):
+        return self._payload
+
+
+class _FakeClient:
+    def __init__(self, response):
+        self.response = response
+        self.calls = []
+
+    async def get(self, url, params=None, headers=None):
+        self.calls.append({"url": url, "params": params, "headers": headers})
+        return self.response
+
+
+class _FakeManager:
+    def __init__(self, client):
+        self.client = client
+
+    async def get_client(self):
+        return self.client
+
+
+@pytest.mark.asyncio
+async def test_youcom_provider_parses_web_results():
+    provider = YouComProvider(
+        api_key="test-key",
+        base_url="https://ydc-index.io/v1/search",
+        max_results=3,
+    )
+    client = _FakeClient(
+        _FakeResponse(
+            {
+                "results": {
+                    "web": [
+                        {
+                            "url": "https://example.com/a",
+                            "title": "Result A",
+                            "description": "Result A description",
+                            "snippets": ["Snippet A1", "Snippet A2"],
+                        },
+                        {
+                            "url": "https://example.com/b",
+                            "title": "Result B",
+                            "snippets": [],
+                        },
+                    ]
+                }
+            }
+        )
+    )
+    provider.client_manager = _FakeManager(client)
+
+    results = await provider.search("agentic search", max_results=2)
+
+    assert len(results) == 2
+    assert results[0].title == "Result A"
+    assert results[0].snippet == "Snippet A1"
+    assert results[1].title == "Result B"
+    assert results[1].snippet == ""
+    assert client.calls[0]["url"] == "https://ydc-index.io/v1/search"
+    assert client.calls[0]["params"] == {"query": "agentic search", "count": 2}
+    assert client.calls[0]["headers"]["X-API-Key"] == "test-key"
+    assert client.calls[0]["headers"]["User-Agent"] == "youdotcom-integration/tarun7r-deep-research-agent"
+
+
+def test_build_search_providers_prefers_youcom_with_duckduckgo_fallback():
+    original_provider = _build_search_providers.__globals__["config"].search_provider
+    original_key = _build_search_providers.__globals__["config"].youcom_api_key
+    original_results = _build_search_providers.__globals__["config"].max_search_results_per_query
+    original_url = _build_search_providers.__globals__["config"].youcom_base_url
+
+    try:
+        cfg = _build_search_providers.__globals__["config"]
+        cfg.search_provider = "youcom"
+        cfg.youcom_api_key = "test-key"
+        cfg.youcom_base_url = "https://ydc-index.io/v1/search"
+        cfg.max_search_results_per_query = 4
+
+        providers = _build_search_providers()
+
+        assert isinstance(providers[0], YouComProvider)
+        assert isinstance(providers[1], DuckDuckGoProvider)
+        assert providers[0].max_results == 4
+        assert providers[1].max_results == 4
+    finally:
+        cfg = _build_search_providers.__globals__["config"]
+        cfg.search_provider = original_provider
+        cfg.youcom_api_key = original_key
+        cfg.max_search_results_per_query = original_results
+        cfg.youcom_base_url = original_url


### PR DESCRIPTION
Why this helps
- The app already has a pluggable search layer, so You.com fits as an optional backend for better search diversity without changing the default DuckDuckGo path.

What changed
- Added a `YouComProvider` that calls the You.com Search API and maps web results into the existing `SearchResult` model.
- Added `SEARCH_PROVIDER=youcom` support and `YDC_API_KEY` / `YOUCOM_SEARCH_BASE_URL` config.
- Kept DuckDuckGo as the default and added DuckDuckGo as a fallback when You.com is selected.
- Documented the new provider in the README and added a focused unit test for parsing/provider selection.

Setup
- Set `SEARCH_PROVIDER=youcom`
- Set `YDC_API_KEY=<your key>`
- Optional: override `YOUCOM_SEARCH_BASE_URL` if needed

Example
```bash
SEARCH_PROVIDER=youcom YDC_API_KEY=... python3 main.py "Impact of quantum computing on cryptography"
```

Validation
- `PYTHONPATH=. uv run --python 3.11 --with pytest --with pytest-asyncio --with ddgs --with tavily-python pytest tests/test_youcom_provider.py -q`

Fallback and error handling
- You.com failures raise structured search errors so the existing provider loop can fall back to DuckDuckGo.
- Default behavior is unchanged for users who do not set `SEARCH_PROVIDER=youcom`.

Tracking
- https://github.com/youdotcom-oss/integration-tracking/issues/169